### PR TITLE
NetReferences don't use GCHandles any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Qml integration with .NET
 [![Qml.Net](https://img.shields.io/nuget/v/Qml.Net.svg?style=flat-square&label=Qml.Net)](http://www.nuget.org/packages/Qml.Net/)
 [![Build status](https://travis-ci.com/pauldotknopf/Qml.Net.svg?branch=master)](https://travis-ci.com/pauldotknopf/Qml.Net) [![Build status](https://ci.appveyor.com/api/projects/status/0ob29turkjslh61j/branch/master?svg=true)](https://ci.appveyor.com/project/pauldotknopf/qml-net)
 
+Supported platforms/runtimes:
 * Runtimes:
   * .NET Framework
   * .NET Core
@@ -14,8 +15,6 @@ A Qml integration with .NET
   * Linux
   * OSX
   * Windows
-
-*As of now, the only focus is on **.NET Core (Linux/OSX/Window)**. The other frameworks should theoretically work though. Drop us an issue if you have any problems. When there is enough demand and user-base, I'd be happy to fully bring in other frameworks.*
 
 ## The idea
 

--- a/README.md
+++ b/README.md
@@ -141,19 +141,23 @@ ApplicationWindow {
 }
 ```
 
-## Building and running
+# Getting started
 
-Setting up an environment takes a little effort, but it is easy enough.
+## Step 1: Install NuGet package
 
-1. Install Qt and Qt Creator.
+```bash
+dotnet add package Qml.Net
+```
+
+## Step 2: Compile the native bindings
+
+*The native libraries aren't shipped with the NuGet package considering the complexity of a Qt/Qml installation, but there are discussions to do so (see [here](https://github.com/pauldotknopf/Qml.Net/issues/33))*
+
+1. Install Qt (at least 5.9) and Qt Creator.
 2. Build and deploy ```src/native/QmlNet/QmlNet.pro```.
-3. Open ```src/net/Qt.NetCore.sln``` and run the sandbox! *Mark sure your ```LD_LIBRARY_PATH``` (etc) is setup for your app to properly find your ```QmlNet``` installation.*
+3. Massage your ```PATH```/```LD_LIBRARY_PATH```/```DYLD_LIBRARY_PATH``` to contain the path that you've deployed the native ```QmlNet``` library.
 
-There will be a proper NuGet/MyGet feed shortly.
-
-Also, there is no plans to ever bundle the native libraries into the NuGet packages considering the complexity of a traditional Qt installation. It will always be recommend/required to install the native ```QmlNet``` on the OS of your choice.
-
-## Currently implemented
+# Currently implemented
 
 - [x] Support for all the basic Qml types and the back-and-forth between them (```DateTime```, ```string```, etc).
 - [x] Reading/setting properties on .NET objects.
@@ -161,7 +165,7 @@ Also, there is no plans to ever bundle the native libraries into the NuGet packa
 - [x] Declaring and activating signals on .NET objects.
 - [x] ```async``` and ```await``` (no return types yet).
 
-## Not implemented (but planned)
+# Not implemented (but planned)
 
 - [ ] Compiling Qml resource files and bundling them within .NET.
 - [ ] Passing dynamic javascript objects to .NET as ```dynamic```. They will be either a live mutable instance, or as a JSON serialized snapshot of the object.

--- a/src/native/QmlNet/QmlNet/qml/NetValue.cpp
+++ b/src/native/QmlNet/QmlNet/qml/NetValue.cpp
@@ -12,9 +12,7 @@ NetValue::~NetValue()
         objectIdNetValuesMap.erase(hit);
     }
     qDebug("NetValue deleted: %s", qPrintable(instance->getTypeInfo()->getClassName()));
-    if(instance != nullptr) {
-        instance->release();
-    }
+    instance = nullptr;
 }
 
 

--- a/src/native/QmlNet/QmlNet/qml/NetValue.cpp
+++ b/src/native/QmlNet/QmlNet/qml/NetValue.cpp
@@ -11,7 +11,6 @@ NetValue::~NetValue()
     {
         objectIdNetValuesMap.erase(hit);
     }
-    qDebug("NetValue deleted: %s", qPrintable(instance->getTypeInfo()->getClassName()));
     instance = nullptr;
 }
 

--- a/src/native/QmlNet/QmlNet/types/Callbacks.cpp
+++ b/src/native/QmlNet/QmlNet/types/Callbacks.cpp
@@ -3,7 +3,7 @@
 typedef bool (*isTypeValidCb)(LPWSTR typeName);
 typedef void (*createLazyTypeInfoCb)(NetTypeInfoContainer* typeInfo);
 typedef void (*loadTypeInfoCb)(NetTypeInfoContainer* typeInfo);
-typedef void (*releaseNetReferenceGCHandleCb)(NetGCHandle* handle, uint64_t objectId);
+typedef void (*releaseNetReferenceCb)(uint64_t objectId);
 typedef void (*releaseNetDelegateGCHandleCb)(NetGCHandle* handle);
 typedef NetReferenceContainer* (*instantiateTypeCb)(NetTypeInfoContainer* type);
 typedef void (*readPropertyCb)(NetPropertyInfoContainer* property, NetReferenceContainer* target, NetVariantContainer* result);
@@ -16,7 +16,7 @@ struct Q_DECL_EXPORT NetTypeInfoManagerCallbacks {
     isTypeValidCb isTypeValid;
     createLazyTypeInfoCb createLazyTypeInfo;
     loadTypeInfoCb loadTypeInfo;
-    releaseNetReferenceGCHandleCb releaseNetReferenceGCHandle;
+    releaseNetReferenceCb releaseNetReference;
     releaseNetDelegateGCHandleCb releaseNetDelegateGCHandle;
     instantiateTypeCb instantiateType;
     readPropertyCb readProperty;
@@ -34,8 +34,8 @@ bool isTypeValid(QString type) {
     return sharedCallbacks.isTypeValid((LPWSTR)type.utf16());
 }
 
-void releaseNetReferenceGCHandle(NetGCHandle* handle, uint64_t objectId) {
-    return sharedCallbacks.releaseNetReferenceGCHandle(handle, objectId);
+void releaseNetReference(uint64_t objectId) {
+    return sharedCallbacks.releaseNetReference(objectId);
 }
 
 void releaseNetDelegateGCHandle(NetGCHandle* handle) {
@@ -134,8 +134,8 @@ Q_DECL_EXPORT bool type_info_callbacks_isTypeValid(LPWSTR typeName) {
     return sharedCallbacks.isTypeValid(typeName);
 }
 
-Q_DECL_EXPORT void type_info_callbacks_releaseNetReferenceGCHandle(NetGCHandle* handle, uint64_t objectId) {
-    sharedCallbacks.releaseNetReferenceGCHandle(handle, objectId);
+Q_DECL_EXPORT void type_info_callbacks_releaseNetReferenceGCHandle(uint64_t objectId) {
+    sharedCallbacks.releaseNetReference(objectId);
 }
 
 Q_DECL_EXPORT void type_info_callbacks_releaseNetDelegateGCHandle(NetGCHandle* handle) {

--- a/src/native/QmlNet/QmlNet/types/Callbacks.h
+++ b/src/native/QmlNet/QmlNet/types/Callbacks.h
@@ -13,7 +13,7 @@
 
 bool isTypeValid(QString type);
 
-void releaseNetReferenceGCHandle(NetGCHandle* handle, uint64_t objectId);
+void releaseNetReference(uint64_t objectId);
 
 void releaseNetDelegateGCHandle(NetGCHandle* handle);
 

--- a/src/native/QmlNet/QmlNet/types/NetReference.cpp
+++ b/src/native/QmlNet/QmlNet/types/NetReference.cpp
@@ -11,7 +11,7 @@ NetReference::NetReference(uint64_t objectId, QSharedPointer<NetTypeInfo> typeIn
 
 NetReference::~NetReference()
 {
-    release();
+    releaseNetReference(objectId);
 }
 
 uint64_t NetReference::getObjectId()
@@ -22,14 +22,6 @@ uint64_t NetReference::getObjectId()
 QSharedPointer<NetTypeInfo> NetReference::getTypeInfo()
 {
     return typeInfo;
-}
-
-void NetReference::release()
-{
-    if(typeInfo != nullptr) {
-        releaseNetReference(objectId);
-        typeInfo = nullptr;
-    }
 }
 
 extern "C" {

--- a/src/native/QmlNet/QmlNet/types/NetReference.h
+++ b/src/native/QmlNet/QmlNet/types/NetReference.h
@@ -10,8 +10,6 @@ public:
     ~NetReference();
     uint64_t getObjectId();
     QSharedPointer<NetTypeInfo> getTypeInfo();
-
-    void release();
 private:
     uint64_t objectId;
     QSharedPointer<NetTypeInfo> typeInfo;

--- a/src/native/QmlNet/QmlNet/types/NetReference.h
+++ b/src/native/QmlNet/QmlNet/types/NetReference.h
@@ -6,15 +6,13 @@
 class NetReference
 {
 public:
-    NetReference(NetGCHandle* gcHandle, uint64_t objectId, QSharedPointer<NetTypeInfo> typeInfo);
+    NetReference(uint64_t objectId, QSharedPointer<NetTypeInfo> typeInfo);
     ~NetReference();
-    NetGCHandle* getGCHandle();
     uint64_t getObjectId();
     QSharedPointer<NetTypeInfo> getTypeInfo();
 
     void release();
 private:
-    NetGCHandle* gcHandle;
     uint64_t objectId;
     QSharedPointer<NetTypeInfo> typeInfo;
 };

--- a/src/net/Qml.Net.Sandbox/Qml.Net.Sandbox.csproj
+++ b/src/net/Qml.Net.Sandbox/Qml.Net.Sandbox.csproj
@@ -4,27 +4,18 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
     <IsPackable>false</IsPackable>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Qml.Net.Tests\Qml.Net.Tests.csproj" />
     <ProjectReference Include="..\Qml.Net\Qml.Net.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="Images\placeholder.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="main.qml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <Compile Remove="Program.Tests.cs" />
     <None Include="Program.Tests.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit.core" Version="2.4.0" />
     <PackageReference Include="xunit.runner.utility" Version="2.4.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Images" />
-    <Folder Include="Qml" />
   </ItemGroup>
 </Project>

--- a/src/net/Qml.Net.Tests/Internal/ObjectTaggerTests.cs
+++ b/src/net/Qml.Net.Tests/Internal/ObjectTaggerTests.cs
@@ -37,7 +37,7 @@ namespace Qml.Net.Tests.Internal
             base.Dispose();
         }
 
-        [Fact]
+        [Fact(Skip = "Destroys all other tests because the object ids get deleted")]
         void Can_detect_id_overflow()
         {
             SetMaxIdTo(10);
@@ -52,7 +52,7 @@ namespace Qml.Net.Tests.Internal
             Assert.Throws<Exception>(() => { lastObj.GetOrCreateTag(); });
         }
 
-        [Fact]
+        [Fact(Skip = "Destroys all other tests because the object ids get deleted")]
         void Can_handle_id_overflow_by_filling_spots()
         {
             SetMaxIdTo(10);
@@ -77,7 +77,7 @@ namespace Qml.Net.Tests.Internal
             tag1.Should().Be(1ul);
         }
 
-        [Fact]
+        [Fact(Skip = "Destroys all other tests because the object ids get deleted")]
         void Can_deliver_same_tag_for_same_instance()
         {
             var obj = new object();

--- a/src/net/Qml.Net.Tests/Internal/ObjectTaggerTests.cs
+++ b/src/net/Qml.Net.Tests/Internal/ObjectTaggerTests.cs
@@ -16,7 +16,7 @@ namespace Qml.Net.Tests.Internal
         {
         }
 
-        [Fact(Skip = "Destroys all other tests because the object ids get deleted")]
+        [Fact]
         void Can_detect_id_overflow()
         {
             ObjectTagger tagger = new ObjectTagger(10);
@@ -31,7 +31,7 @@ namespace Qml.Net.Tests.Internal
             Assert.Throws<Exception>(() => { tagger.GetOrCreateTag(lastObj); });
         }
 
-        [Fact(Skip = "Destroys all other tests because the object ids get deleted")]
+        [Fact]
         void Can_handle_id_overflow_by_filling_spots()
         {
             ObjectTagger tagger = new ObjectTagger(10);
@@ -56,7 +56,7 @@ namespace Qml.Net.Tests.Internal
             tag1.Should().Be(1ul);
         }
 
-        [Fact(Skip = "Destroys all other tests because the object ids get deleted")]
+        [Fact]
         void Can_deliver_same_tag_for_same_instance()
         {
             ObjectTagger tagger = new ObjectTagger();

--- a/src/net/Qml.Net/Internal/DefaultCallbacks.cs
+++ b/src/net/Qml.Net/Internal/DefaultCallbacks.cs
@@ -145,9 +145,9 @@ namespace Qml.Net.Internal
             }
         }
         
-        public void ReleaseNetReferenceGCHandle(IntPtr handle, UInt64 objectId)
+        public void ReleaseNetReference(UInt64 objectId)
         {
-            NetReference.ReleaseGCHandle(((GCHandle)handle), objectId);
+            NetReference.OnRelease(objectId);
         }
 
         public void ReleaseNetDelegateGCHandle(IntPtr handle)

--- a/src/net/Qml.Net/Internal/IQmlInteropBehavior.cs
+++ b/src/net/Qml.Net/Internal/IQmlInteropBehavior.cs
@@ -11,8 +11,8 @@ namespace Qml.Net.Internal
 
         void OnNetTypeInfoCreated(NetTypeInfo netTypeInfo, Type forType);
 
-        void OnNetReferenceCreatedForObject(object instance, UInt64 objectId);
+        void OnObjectEntersNative(object instance, UInt64 objectId);
 
-        void OnNetReferenceDeletedForObject(object instance, UInt64 objectId);
+        void OnObjectLeavesNative(object instance, UInt64 objectId);
     }
 }

--- a/src/net/Qml.Net/Internal/InteropBehaviors.cs
+++ b/src/net/Qml.Net/Internal/InteropBehaviors.cs
@@ -45,7 +45,7 @@ namespace Qml.Net.Internal
             }
         }
 
-        internal static void OnNetReferenceCreatedForObject(object instance, UInt64 objectId)
+        internal static void OnObjectEntersNative(object instance, UInt64 objectId)
         {
             if (instance == null)
             {
@@ -54,11 +54,11 @@ namespace Qml.Net.Internal
             var type = instance.GetType();
             foreach (var behavior in GetApplicableInteropBehaviors(type))
             {
-                behavior.OnNetReferenceCreatedForObject(instance, objectId);
+                behavior.OnObjectEntersNative(instance, objectId);
             }
         }
 
-        internal static void OnNetReferenceDeletedForObject(object instance, UInt64 objectId)
+        internal static void OnObjectLeavesNative(object instance, UInt64 objectId)
         {
             if (instance == null)
             {
@@ -67,7 +67,7 @@ namespace Qml.Net.Internal
             var type = instance.GetType();
             foreach (var behavior in GetApplicableInteropBehaviors(type))
             {
-                behavior.OnNetReferenceDeletedForObject(instance, objectId);
+                behavior.OnObjectLeavesNative(instance, objectId);
             }
         }
     }

--- a/src/net/Qml.Net/Internal/InteropBehaviors.cs
+++ b/src/net/Qml.Net/Internal/InteropBehaviors.cs
@@ -20,9 +20,16 @@ namespace Qml.Net.Internal
         /// Registers an additional Qml Interop behavior. This behavior only gets applied to types and instances created or registered after this behavior registration 
         /// </summary> 
         /// <param name="behavior"></param> 
-        public static void RegisterQmlInteropBehavior(IQmlInteropBehavior behavior)
+        public static void RegisterQmlInteropBehavior(IQmlInteropBehavior behavior, bool addIfTypeAlreadyExists = false)
         {
-            _QmlInteropBehaviors.Add(behavior);
+            if(!addIfTypeAlreadyExists && _QmlInteropBehaviors.Any(ib => ib.GetType() == behavior.GetType()))
+            {
+                return;
+            }
+            if (!_QmlInteropBehaviors.Contains(behavior))
+            {
+                _QmlInteropBehaviors.Add(behavior);
+            }
         }
 
         public static void ClearQmlInteropBehaviors()

--- a/src/net/Qml.Net/Internal/ObjectTagger.cs
+++ b/src/net/Qml.Net/Internal/ObjectTagger.cs
@@ -30,12 +30,18 @@ namespace Qml.Net.Internal
 
         public void Dispose()
         {
-            _Tagger.FreeId(Id);
+            if (_Tagger != null)
+            {
+                _Tagger.FreeId(Id);
+            }
         }
 
         ~ObjectId()
         {
-            _Tagger.FreeId(Id);
+            if(_Tagger != null)
+            {
+                _Tagger.FreeId(Id);
+            }
         }
     }
 

--- a/src/net/Qml.Net/Internal/Types/Callbacks.cs
+++ b/src/net/Qml.Net/Internal/Types/Callbacks.cs
@@ -10,7 +10,7 @@ namespace Qml.Net.Internal.Types
         public IntPtr IsTypeValid;
         public IntPtr CreateLazyTypeInfo;
         public IntPtr LoadTypeInfo;
-        public IntPtr ReleaseNetReferenceGCHandle;
+        public IntPtr ReleaseNetReference;
         public IntPtr ReleaseNetDelegateGCHandle;
         public IntPtr InstantiateType;
         public IntPtr ReadProperty;
@@ -29,7 +29,7 @@ namespace Qml.Net.Internal.Types
         bool IsTypeValid([MarshalAs(UnmanagedType.LPWStr)]string typeName);
 
         [NativeSymbol(Entrypoint = "type_info_callbacks_releaseNetReferenceGCHandle")]
-        void ReleaseNetReferenceGCHandle(IntPtr handle, UInt64 objectId);
+        void ReleaseNetReference(UInt64 objectId);
 
         [NativeSymbol(Entrypoint = "type_info_callbacks_releaseNetDelegateGCHandle")]
         void ReleaseNetDelegateGCHandle(IntPtr handle);
@@ -51,7 +51,7 @@ namespace Qml.Net.Internal.Types
     {
         bool IsTypeValid(string typeName);
 
-        void ReleaseNetReferenceGCHandle(IntPtr handle, UInt64 objectId);
+        void ReleaseNetReference(UInt64 objectId);
 
         void ReleaseNetDelegateGCHandle(IntPtr handle);
 
@@ -78,7 +78,7 @@ namespace Qml.Net.Internal.Types
         IsTypeValidDelegate _isTypeValidDelegate;
         CreateLazyTypeInfoDelegate _createLazyTypeInfoDelegate;
         LoadTypeInfoDelegate _loadTypeInfoDelegate;
-        ReleaseNetReferenceGCHandleDelegate _releaseNetReferenceGCHandleDelegate;
+        ReleaseNetReferenceDelegate _releaseNetReferenceDelegate;
         ReleaseNetDelegateGCHandleDelegate _releaseNetDelegateGCHandleDelegate;
         InstantiateTypeDelgate _instantiateTypeDelgate;
         ReadPropertyDelegate _readPropertyDelegate;
@@ -97,7 +97,7 @@ namespace Qml.Net.Internal.Types
         delegate void LoadTypeInfoDelegate(IntPtr typeInfo);
         
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        delegate void ReleaseNetReferenceGCHandleDelegate(IntPtr handle, UInt64 objectId);
+        delegate void ReleaseNetReferenceDelegate(UInt64 objectId);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         delegate void ReleaseNetDelegateGCHandleDelegate(IntPtr handle);
@@ -127,8 +127,8 @@ namespace Qml.Net.Internal.Types
             _isTypeValidDelegate = IsTypeValid;
             GCHandle.Alloc(_isTypeValidDelegate);
 
-            _releaseNetReferenceGCHandleDelegate = ReleaseNetReferenceGCHandle;
-            GCHandle.Alloc(_releaseNetReferenceGCHandleDelegate);
+            _releaseNetReferenceDelegate = ReleaseNetReference;
+            GCHandle.Alloc(_releaseNetReferenceDelegate);
 
             _releaseNetDelegateGCHandleDelegate = ReleaseNetDelegateGCHandle;
             GCHandle.Alloc(_releaseNetDelegateGCHandleDelegate);
@@ -163,9 +163,9 @@ namespace Qml.Net.Internal.Types
             return _callbacks.IsTypeValid(typeName);
         }
         
-        private void ReleaseNetReferenceGCHandle(IntPtr handle, UInt64 objectId)
+        private void ReleaseNetReference(UInt64 objectId)
         {
-            _callbacks.ReleaseNetReferenceGCHandle(handle, objectId);
+            _callbacks.ReleaseNetReference(objectId);
         }
 
         private void ReleaseNetDelegateGCHandle(IntPtr handle)
@@ -222,7 +222,7 @@ namespace Qml.Net.Internal.Types
                 IsTypeValid = Marshal.GetFunctionPointerForDelegate(_isTypeValidDelegate),
                 CreateLazyTypeInfo = Marshal.GetFunctionPointerForDelegate(_createLazyTypeInfoDelegate),
                 LoadTypeInfo = Marshal.GetFunctionPointerForDelegate(_loadTypeInfoDelegate),
-                ReleaseNetReferenceGCHandle = Marshal.GetFunctionPointerForDelegate(_releaseNetReferenceGCHandleDelegate),
+                ReleaseNetReference = Marshal.GetFunctionPointerForDelegate(_releaseNetReferenceDelegate),
                 ReleaseNetDelegateGCHandle = Marshal.GetFunctionPointerForDelegate(_releaseNetDelegateGCHandleDelegate),
                 InstantiateType = Marshal.GetFunctionPointerForDelegate(_instantiateTypeDelgate),
                 ReadProperty = Marshal.GetFunctionPointerForDelegate(_readPropertyDelegate),

--- a/src/net/Qml.Net/Internal/Types/NetReference.cs
+++ b/src/net/Qml.Net/Internal/Types/NetReference.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
@@ -10,8 +11,8 @@ namespace Qml.Net.Internal.Types
 {
     internal class NetReference : BaseDisposable
     {
-        private NetReference(IntPtr gcHandle, UInt64 objectId, NetTypeInfo type, bool ownsHandle = true)
-            :base(Interop.NetReference.Create(gcHandle, objectId, type.Handle), ownsHandle)
+        private NetReference(UInt64 objectId, NetTypeInfo type, bool ownsHandle = true)
+            :base(Interop.NetReference.Create(objectId, type.Handle), ownsHandle)
         {
         }
 
@@ -25,8 +26,11 @@ namespace Qml.Net.Internal.Types
         {
             get
             {
-                var handle = Interop.NetReference.GetHandle(Handle);
-                return ((GCHandle) handle).Target;
+                if(ObjectIdReferenceTracker.TryGetObjectFor(ObjectId, out var obj))
+                {
+                    return obj;
+                }
+                return null;
             }
         }
 
@@ -83,21 +87,18 @@ namespace Qml.Net.Internal.Types
             
             var typeInfo = NetTypeManager.GetTypeInfo(GetUnproxiedType(value.GetType()));
             if(typeInfo == null) throw new InvalidOperationException($"Couldn't create type info from {value.GetType().AssemblyQualifiedName}");
-            var handle = GCHandle.Alloc(value);
 
             objectId = value.GetOrCreateTag();
-            var newNetReference = new NetReference(GCHandle.ToIntPtr(handle), objectId.Value, typeInfo);
+            var newNetReference = new NetReference(objectId.Value, typeInfo);
 
-            InteropBehaviors.OnNetReferenceCreatedForObject(value, objectId.Value);
+            ObjectIdReferenceTracker.OnReferenceCreated(value, objectId.Value);
 
             return newNetReference;
         }
 
-        public static void ReleaseGCHandle(GCHandle handle, UInt64 objectId)
+        public static void OnRelease(UInt64 objectId)
         {
-            var obj = handle.Target;
-            handle.Free();
-            InteropBehaviors.OnNetReferenceDeletedForObject(obj, objectId);
+            ObjectIdReferenceTracker.OnReferenceReleased(objectId);
         }
 
         #endregion
@@ -106,17 +107,84 @@ namespace Qml.Net.Internal.Types
     internal interface INetReferenceInterop
     {   
         [NativeSymbol(Entrypoint = "net_instance_create")]
-        IntPtr Create(IntPtr handle, UInt64 objectId, IntPtr type);
+        IntPtr Create(UInt64 objectId, IntPtr type);
         [NativeSymbol(Entrypoint = "net_instance_destroy")]
         void Destroy(IntPtr instance);
         [NativeSymbol(Entrypoint = "net_instance_clone")]
         IntPtr Clone(IntPtr instance);
 
-        [NativeSymbol(Entrypoint = "net_instance_getHandle")]
-        IntPtr GetHandle(IntPtr instance);
         [NativeSymbol(Entrypoint = "net_instance_getObjectId")]
         UInt64 GetObjectId(IntPtr instance);
         [NativeSymbol(Entrypoint = "net_instance_activateSignal")]
         bool ActivateSignal(IntPtr instance, [MarshalAs(UnmanagedType.LPWStr)]string signalName, IntPtr variants);
+    }
+
+    internal static class ObjectIdReferenceTracker
+    {
+        class ObjectEntry
+        {
+            public object Obj { get; private set; }
+            public UInt64 Counter { get; set; }
+
+            public ObjectEntry(object obj, UInt64 count)
+            {
+                Obj = obj;
+                Counter = count;
+            }
+        }
+
+        private static Dictionary<UInt64, ObjectEntry> _ObjectIdObjectLookup = new Dictionary<ulong, ObjectEntry>();
+        private static object _LockObject = new object();
+
+        internal static bool TryGetObjectFor(UInt64 objectId, out object obj)
+        {
+            lock(_LockObject)
+            {
+                if(_ObjectIdObjectLookup.ContainsKey(objectId))
+                {
+                    obj = _ObjectIdObjectLookup[objectId].Obj;
+                    return true;
+                }
+                obj = null;
+                return false;
+            }
+        }
+
+        internal static void OnReferenceReleased(UInt64 objectId)
+        {
+            lock (_LockObject)
+            {
+                if (!_ObjectIdObjectLookup.ContainsKey(objectId))
+                {
+                    throw new InvalidOperationException("Releasing a NetReference that hasn't been counted!");
+                }
+                _ObjectIdObjectLookup[objectId].Counter--;
+                //when there are no more QML references
+                if (_ObjectIdObjectLookup[objectId].Counter == 0)
+                {
+                    var obj = _ObjectIdObjectLookup[objectId].Obj;
+                    //remove object entry
+                    _ObjectIdObjectLookup.Remove(objectId);
+                    //and notify the behaviors
+                    InteropBehaviors.OnObjectLeavesNative(obj, objectId);
+                }
+            }
+        }
+
+        internal static void OnReferenceCreated(object obj, UInt64 objectId)
+        {
+            lock (_LockObject)
+            {
+                if (!_ObjectIdObjectLookup.ContainsKey(objectId))
+                {
+                    _ObjectIdObjectLookup[objectId] = new ObjectEntry(obj, 1);
+                    InteropBehaviors.OnObjectEntersNative(obj, objectId);
+                }
+                else
+                {
+                    _ObjectIdObjectLookup[objectId].Counter++;
+                }
+            }
+        }
     }
 }

--- a/src/net/Qml.Net/Internal/Types/NetReference.cs
+++ b/src/net/Qml.Net/Internal/Types/NetReference.cs
@@ -30,7 +30,7 @@ namespace Qml.Net.Internal.Types
                 {
                     return obj;
                 }
-                return null;
+                throw new InvalidOperationException($"No object found for object id {ObjectId}");
             }
         }
 

--- a/src/net/Qml.Net/QQmlApplicationEngine.cs
+++ b/src/net/Qml.Net/QQmlApplicationEngine.cs
@@ -35,9 +35,18 @@ namespace Qml.Net
             return Interop.QQmlApplicationEngine.RegisterType(type.Handle, uri, versionMajor, versionMinor, qmlName);
         }
 
+        /// <summary>
+        /// Activates the MVVM behavior.
+        /// This Behavior automatically connects INotifyPropertyChanged instances with appropriate signals on the QML side
+        /// and triggers those signals whenever the PropertyChanged event of the INotifyPropertyChanged instances is triggered.
+        /// 
+        /// Call this before any INotifyPropertyChanged type is registered! 
+        /// Otherwise the behavior might not include
+        /// INotifyPropertyChanged types that were registered (implicitly or explicitly) before this call
+        /// </summary>
         public static void ActivateMVVMBehavior()
         {
-            InteropBehaviors.RegisterQmlInteropBehavior(new MVVMQmlInteropBehavior());
+            InteropBehaviors.RegisterQmlInteropBehavior(new MVVMQmlInteropBehavior(), false);
         }
 
         public void AddImportPath(string path)


### PR DESCRIPTION
References are counted manually on .Net side
Behaviors now don't get an event on each NetReference create / delete but when an .Net object enters Native the first time and when it leaves the Native space